### PR TITLE
Add persistent DB test and Beeminder logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ A personal Flask application that listens for Todoist webhooks, starts/stops tim
 - **Start Timer**: Comment "`start timer`" on a Todoist task to begin tracking time.
 - **Stop Timer**: Comment "`stop timer`" on the same task to stop tracking and save the elapsed time.
 - **Automatic Updates**: Task descriptions are updated in the background to show how long a timer has been running or the total accumulated time.
+- **Beeminder Linking**: Comment `add to beeminder <goal_slug>` to map a task to a Beeminder goal. Use `remove from beeminder` to unlink and `beeminder status` to check the mapping.
 - **Security**: Validates webhooks from Todoist via HMAC signatures.
 
 ## How It Works
 
 1. **Webhook Endpoint**:
-   - The application exposes a single `/webhook` endpoint which Todoist calls whenever a note/comment is added to a task.
-   - If the comment contains specific trigger phrases (like `start timer` or `stop timer`), the application processes them accordingly.
+   - The application exposes a single `/webhook` endpoint which Todoist calls for various events.
+   - Comments on tasks trigger timer controls and Beeminder linking.
+   - Task completion events trigger Beeminder datapoints for linked tasks.
 
 2. **Timer Logic**:
    - Uses an in-memory Python dictionary (`timers`) keyed by `user_id:task_id` to track the start times.
@@ -24,7 +26,8 @@ A personal Flask application that listens for Todoist webhooks, starts/stops tim
    - Expects a `.env` file with:
      - `TODOIST_API_TOKEN`
      - `TODOIST_CLIENT_SECRET`
-   - These are used to authenticate requests to Todoist and validate incoming webhooks.
+     - `BEEMINDER_AUTH_TOKEN` *(required for Beeminder integration)*
+   - These are used to authenticate requests to Todoist/Beeminder and validate incoming webhooks.
 
 ## Requirements
 
@@ -89,6 +92,15 @@ pip install -r requirements.txt
 
 - **Multiple Timers**:
   Each user-task combination is tracked independently. Starting a new timer on a different task won’t affect other tasks.
+
+- **Link to Beeminder**:
+  Comment `add to beeminder <goal_slug>` on a task to log its completions to Beeminder.
+
+- **Unlink from Beeminder**:
+  Comment `remove from beeminder` to stop logging to Beeminder.
+
+- **Check Beeminder Status**:
+  Comment `beeminder status` to see whether the task is linked and to which goal.
 
 ## Troubleshooting
 

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ import hmac
 import hashlib
 import base64
 import requests
+import sqlite3
 
 # New imports for scheduling and regex
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -28,11 +29,63 @@ app = Flask(__name__)
 # In-memory store for timers
 timers = {}
 
+# Database configuration for linking Todoist tasks to Beeminder goals
+DB_PATH = os.getenv("TASK_LINK_DB", "task_links.db")
+app.config["DB_PATH"] = DB_PATH
+
 TODOIST_API_BASE_URL = "https://api.todoist.com/rest/v2"
 TODOIST_API_TOKEN = os.getenv("TODOIST_API_TOKEN")
 
 if not TODOIST_API_TOKEN:
     raise RuntimeError("TODOIST_API_TOKEN not found in environment variables.")
+
+
+def get_db_connection():
+    """Return a SQLite connection using the configured DB path."""
+    conn = sqlite3.connect(app.config["DB_PATH"])
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db():
+    """Initialize the SQLite database for task links."""
+    conn = get_db_connection()
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS task_link (task_id TEXT PRIMARY KEY, goal_slug TEXT)"
+    )
+    conn.commit()
+    conn.close()
+
+
+def add_task_link(task_id: str, goal_slug: str) -> None:
+    """Persist a mapping of task_id -> goal_slug."""
+    conn = get_db_connection()
+    conn.execute(
+        "REPLACE INTO task_link (task_id, goal_slug) VALUES (?, ?)", (task_id, goal_slug)
+    )
+    conn.commit()
+    conn.close()
+
+
+def remove_task_link(task_id: str) -> None:
+    """Remove a mapping for the given task_id."""
+    conn = get_db_connection()
+    conn.execute("DELETE FROM task_link WHERE task_id = ?", (task_id,))
+    conn.commit()
+    conn.close()
+
+
+def get_task_link(task_id: str):
+    """Return the goal_slug mapped to the task_id, or None."""
+    conn = get_db_connection()
+    cur = conn.execute("SELECT goal_slug FROM task_link WHERE task_id = ?", (task_id,))
+    row = cur.fetchone()
+    conn.close()
+    return row["goal_slug"] if row else None
+
+
+# Ensure the database exists on import
+init_db()
 
 def validate_hmac(payload, received_hmac):
     """Validate the HMAC signature in the request."""
@@ -156,124 +209,178 @@ def webhook():
             app.logger.error("Missing event_name in payload.")
             return jsonify({"error": "Missing event_name in payload."}), 400
 
-        # We only handle note:added
-        if event_name != "note:added":
-            app.logger.info(f"Unhandled event type: {event_name}")
-            return jsonify({"message": "Event not handled"}), 200
-
         # Extract relevant fields from `event_data`
         event_data = data.get("event_data", {})
         if not event_data:
             app.logger.error("Missing event_data in payload.")
             return jsonify({"error": "Missing event_data in payload."}), 400
 
-        task_id = event_data.get("item", {}).get("id")  # Extract task_id from `item`
-        user_id = event_data.get("item", {}).get("user_id")  # Extract user_id from `item`
-        comment_text = event_data.get("content", "").lower()
+        if event_name == "note:added":
+            task_id = event_data.get("item", {}).get("id")
+            user_id = event_data.get("item", {}).get("user_id")
+            comment_text = event_data.get("content", "").lower()
 
-        if not task_id or not user_id:
-            app.logger.error("Invalid payload: Missing task_id or user_id.")
-            return jsonify({"error": "Invalid payload: Missing task_id or user_id."}), 400
+            if not task_id or not user_id:
+                app.logger.error("Invalid payload: Missing task_id or user_id.")
+                return jsonify({"error": "Invalid payload: Missing task_id or user_id."}), 400
 
-        # Log current timers for debugging
-        app.logger.info(f"Current timers: {timers}")
-
-        # Timer logic
-        timer_key = f"{user_id}:{task_id}"
-        app.logger.info(f"Processing command for key: {timer_key}")
-
-        if "start timer" in comment_text:
-            # START TIMER
-            if timer_key in timers:
-                app.logger.info(f"Timer already running for key: {timer_key}")
-                return jsonify({"message": "Timer already running."}), 200
-
-            timers[timer_key] = {"start_time": datetime.datetime.now()}
-            app.logger.info(f"Timer started for key: {timer_key}")
-
-            # INSTANT FEEDBACK: Immediately update task description with "(Timer Running: 0 minutes)"
-            current_desc = get_current_description(task_id)
-            if current_desc is not None:
-                # Remove any old snippet
-                pattern = r"\(Timer Running: \d+ minutes\)"
-                updated_desc = re.sub(pattern, "", current_desc).strip()
-
-                # Add snippet for immediate feedback
-                timer_snippet = "(Timer Running: 0 minutes)"
-                if updated_desc:
-                    updated_desc = f"{updated_desc} {timer_snippet}".strip()
-                else:
-                    updated_desc = timer_snippet
-
-                update_todoist_description(task_id, updated_desc)
-
-            return jsonify({"message": "Timer started."}), 200
-
-        elif "stop timer" in comment_text:
-            # STOP TIMER
-            if timer_key not in timers:
-                app.logger.info(f"No timer running for key: {timer_key}")
-                post_todoist_comment(task_id, "No timer found to stop.")
-                return jsonify({"message": "No timer running for this task."}), 200
-
-            start_time = timers[timer_key]["start_time"]
-            elapsed_time = datetime.datetime.now() - start_time
-            del timers[timer_key]
-
-            # Calculate final elapsed time
-            elapsed_seconds = elapsed_time.total_seconds()
-            hours, remainder = divmod(elapsed_seconds, 3600)
-            minutes, seconds = divmod(remainder, 60)
-            elapsed_str = f"{int(hours)}h {int(minutes)}m {int(seconds)}s"
-
-            # OPTIONAL: Post the elapsed time as a comment (can remove if undesired)
-            post_todoist_comment(task_id, f"Elapsed time: {elapsed_str}")
-
-            # Fetch current description
-            current_desc = get_current_description(task_id)
-            if current_desc is not None:
-                # Check if there is already a "Total Time" snippet
-                total_time_pattern = r"\(Total Time: (\d+)h (\d+)m (\d+)s\)"
-                match = re.search(total_time_pattern, current_desc)
-
+            # Handle Beeminder commands
+            if comment_text.startswith("add to beeminder"):
+                match = re.search(r"add to beeminder\s+(\S+)", comment_text)
                 if match:
-                    # Extract existing hours, minutes, seconds
-                    existing_hours = int(match.group(1))
-                    existing_minutes = int(match.group(2))
-                    existing_seconds = int(match.group(3))
-
-                    # Add new elapsed time to the existing time
-                    total_seconds = (
-                        existing_hours * 3600 +
-                        existing_minutes * 60 +
-                        existing_seconds +
-                        elapsed_seconds
-                    )
-                    new_hours, remainder = divmod(total_seconds, 3600)
-                    new_minutes, new_seconds = divmod(remainder, 60)
-                    new_elapsed_str = f"{int(new_hours)}h {int(new_minutes)}m {int(new_seconds)}s"
+                    goal = match.group(1)
+                    add_task_link(task_id, goal)
+                    post_todoist_comment(task_id, f"Task linked to goal '{goal}'.")
+                    return jsonify({"message": "Task linked"}), 200
+            elif comment_text.startswith("remove from beeminder"):
+                remove_task_link(task_id)
+                post_todoist_comment(task_id, "Task unlinked from Beeminder.")
+                return jsonify({"message": "Task unlinked"}), 200
+            elif comment_text.startswith("beeminder status"):
+                goal = get_task_link(task_id)
+                if goal:
+                    post_todoist_comment(task_id, f"Task linked to goal '{goal}'.")
                 else:
-                    # No existing "Total Time" snippet; use new elapsed time as-is
-                    new_elapsed_str = elapsed_str
+                    post_todoist_comment(task_id, "Task not linked to Beeminder.")
+                return jsonify({"message": "Status sent"}), 200
 
-                # Remove any existing "Total Time" snippet and "Timer Running" snippet
-                total_time_and_running_pattern = r"\(Total Time: .*?\)|\(Timer Running: .*?\)"
-                updated_desc = re.sub(total_time_and_running_pattern, "", current_desc).strip()
+            # Log current timers for debugging
+            app.logger.info(f"Current timers: {timers}")
 
-                # Append the new total time
-                total_time_snippet = f"(Total Time: {new_elapsed_str})"
-                if updated_desc:
-                    updated_desc = f"{updated_desc} {total_time_snippet}".strip()
+            # Timer logic
+            timer_key = f"{user_id}:{task_id}"
+            app.logger.info(f"Processing command for key: {timer_key}")
+
+            if "start timer" in comment_text:
+                # START TIMER
+                if timer_key in timers:
+                    app.logger.info(f"Timer already running for key: {timer_key}")
+                    return jsonify({"message": "Timer already running."}), 200
+
+                timers[timer_key] = {"start_time": datetime.datetime.now()}
+                app.logger.info(f"Timer started for key: {timer_key}")
+
+                # INSTANT FEEDBACK: Immediately update task description with "(Timer Running: 0 minutes)"
+                current_desc = get_current_description(task_id)
+                if current_desc is not None:
+                    # Remove any old snippet
+                    pattern = r"\(Timer Running: \d+ minutes\)"
+                    updated_desc = re.sub(pattern, "", current_desc).strip()
+
+                    # Add snippet for immediate feedback
+                    timer_snippet = "(Timer Running: 0 minutes)"
+                    if updated_desc:
+                        updated_desc = f"{updated_desc} {timer_snippet}".strip()
+                    else:
+                        updated_desc = timer_snippet
+
+                    update_todoist_description(task_id, updated_desc)
+
+                return jsonify({"message": "Timer started."}), 200
+
+            elif "stop timer" in comment_text:
+                # STOP TIMER
+                if timer_key not in timers:
+                    app.logger.info(f"No timer running for key: {timer_key}")
+                    post_todoist_comment(task_id, "No timer found to stop.")
+                    return jsonify({"message": "No timer running for this task."}), 200
+
+                start_time = timers[timer_key]["start_time"]
+                elapsed_time = datetime.datetime.now() - start_time
+                del timers[timer_key]
+
+                # Calculate final elapsed time
+                elapsed_seconds = elapsed_time.total_seconds()
+                hours, remainder = divmod(elapsed_seconds, 3600)
+                minutes, seconds = divmod(remainder, 60)
+                elapsed_str = f"{int(hours)}h {int(minutes)}m {int(seconds)}s"
+
+                # OPTIONAL: Post the elapsed time as a comment (can remove if undesired)
+                post_todoist_comment(task_id, f"Elapsed time: {elapsed_str}")
+
+                # Fetch current description
+                current_desc = get_current_description(task_id)
+                if current_desc is not None:
+                    # Check if there is already a "Total Time" snippet
+                    total_time_pattern = r"\(Total Time: (\d+)h (\d+)m (\d+)s\)"
+                    match = re.search(total_time_pattern, current_desc)
+
+                    if match:
+                        # Extract existing hours, minutes, seconds
+                        existing_hours = int(match.group(1))
+                        existing_minutes = int(match.group(2))
+                        existing_seconds = int(match.group(3))
+
+                        # Add new elapsed time to the existing time
+                        total_seconds = (
+                            existing_hours * 3600 +
+                            existing_minutes * 60 +
+                            existing_seconds +
+                            elapsed_seconds
+                        )
+                        new_hours, remainder = divmod(total_seconds, 3600)
+                        new_minutes, new_seconds = divmod(remainder, 60)
+                        new_elapsed_str = f"{int(new_hours)}h {int(new_minutes)}m {int(new_seconds)}s"
+                    else:
+                        # No existing "Total Time" snippet; use new elapsed time as-is
+                        new_elapsed_str = elapsed_str
+
+                    # Remove any existing "Total Time" snippet and "Timer Running" snippet
+                    total_time_and_running_pattern = r"\(Total Time: .*?\)|\(Timer Running: .*?\)"
+                    updated_desc = re.sub(total_time_and_running_pattern, "", current_desc).strip()
+
+                    # Append the new total time
+                    total_time_snippet = f"(Total Time: {new_elapsed_str})"
+                    if updated_desc:
+                        updated_desc = f"{updated_desc} {total_time_snippet}".strip()
+                    else:
+                        updated_desc = total_time_snippet
+
+                    update_todoist_description(task_id, updated_desc)
+
+                app.logger.info(f"Timer stopped for key: {timer_key}. Elapsed time: {elapsed_str}")
+                return jsonify({"message": f"Timer stopped. Total time: {elapsed_str}"}), 200
+
+            app.logger.info("No action taken for the comment.")
+            return jsonify({"message": "No action taken."}), 200
+
+        elif event_name == "item:completed":
+            # Handle task completion: send datapoint to Beeminder if linked
+            task_id = (
+                event_data.get("id")
+                or event_data.get("item", {}).get("id")
+                or event_data.get("task_id")
+            )
+            if not task_id:
+                app.logger.error("Missing task_id in completion event.")
+                return jsonify({"message": "Completion processed"}), 200
+
+            goal = get_task_link(task_id)
+            if goal:
+                auth_token = os.getenv("BEEMINDER_AUTH_TOKEN")
+                if not auth_token:
+                    app.logger.error("BEEMINDER_AUTH_TOKEN not found in environment.")
                 else:
-                    updated_desc = total_time_snippet
+                    url = f"https://www.beeminder.com/api/v1/users/me/goals/{goal}/datapoints.json"
+                    requestid = data.get("event_id", f"{task_id}-{datetime.datetime.utcnow().timestamp()}")
+                    payload = {"value": 1, "auth_token": auth_token, "requestid": requestid}
+                    try:
+                        response = requests.post(url, data=payload)
+                        if response.status_code not in (200, 201):
+                            app.logger.error(
+                                f"Failed to send datapoint to Beeminder: {response.status_code} {response.text}"
+                            )
+                        else:
+                            app.logger.info(
+                                f"Logged completion of task {task_id} to Beeminder goal '{goal}'."
+                            )
+                    except Exception as e:
+                        app.logger.error(f"Error sending datapoint to Beeminder: {e}")
+            return jsonify({"message": "Completion processed"}), 200
 
-                update_todoist_description(task_id, updated_desc)
-
-            app.logger.info(f"Timer stopped for key: {timer_key}. Elapsed time: {elapsed_str}")
-            return jsonify({"message": f"Timer stopped. Total time: {elapsed_str}"}), 200
-
-        app.logger.info("No action taken for the comment.")
-        return jsonify({"message": "No action taken."}), 200
+        else:
+            app.logger.info(f"Unhandled event type: {event_name}")
+            return jsonify({"message": "Event not handled"}), 200
 
     except Exception as e:
         app.logger.error(f"Error in webhook processing: {e}")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,19 @@
 import datetime
+import os
 import pytest
+import tempfile
 from unittest.mock import patch, MagicMock
-from app import app, timers
+
+# Ensure required environment variables for importing the app
+os.environ.setdefault("TODOIST_API_TOKEN", "test_token")
+os.environ.setdefault("TODOIST_CLIENT_SECRET", "secret")
+
+# Use a temporary database path for the default DB to avoid polluting repo
+fd, default_db_path = tempfile.mkstemp()
+os.close(fd)
+os.environ.setdefault("TASK_LINK_DB", default_db_path)
+
+from app import app, timers, init_db, get_task_link, add_task_link
 
 @pytest.fixture
 def client():
@@ -12,6 +24,31 @@ def client():
 def mock_validate_hmac(payload, received_hmac):
     """Mock HMAC validation to always return True for tests."""
     return True
+
+
+def setup_in_memory_db():
+    """Utility to configure an isolated SQLite DB for tests."""
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    app.config["DB_PATH"] = path
+    init_db()
+
+
+def test_database_persistence():
+    """Verify that task links persist across database reinitialization."""
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    try:
+        app.config["DB_PATH"] = path
+        init_db()
+        add_task_link("t1", "goal1")
+        assert get_task_link("t1") == "goal1"
+
+        # Simulate app restart by re-initializing the DB
+        init_db()
+        assert get_task_link("t1") == "goal1"
+    finally:
+        os.unlink(path)
 
 @patch("app.validate_hmac", side_effect=mock_validate_hmac)
 def test_start_timer(mock_hmac, client):
@@ -86,6 +123,65 @@ def test_unhandled_event_type(mock_hmac, client):
     response = client.post("/webhook", json=payload, headers=headers)
     assert response.status_code == 200
     assert b"Event not handled" in response.data
+
+
+@patch("app.validate_hmac", side_effect=mock_validate_hmac)
+@patch("app.post_todoist_comment")
+def test_add_to_beeminder(mock_comment, mock_hmac, client):
+    """Link a task to a Beeminder goal via comment."""
+    setup_in_memory_db()
+    payload = {
+        "event_name": "note:added",
+        "event_data": {
+            "content": "add to beeminder salah",
+            "item": {"id": "123", "user_id": "u1"},
+        },
+    }
+    headers = {"X-Todoist-Hmac-SHA256": "mock"}
+    response = client.post("/webhook", json=payload, headers=headers)
+    assert response.status_code == 200
+    assert get_task_link("123") == "salah"
+
+
+@patch("app.validate_hmac", side_effect=mock_validate_hmac)
+@patch("app.post_todoist_comment")
+def test_remove_from_beeminder(mock_comment, mock_hmac, client):
+    """Unlink a task from Beeminder."""
+    setup_in_memory_db()
+    add_task_link("123", "salah")
+    payload = {
+        "event_name": "note:added",
+        "event_data": {
+            "content": "remove from beeminder",
+            "item": {"id": "123", "user_id": "u1"},
+        },
+    }
+    headers = {"X-Todoist-Hmac-SHA256": "mock"}
+    response = client.post("/webhook", json=payload, headers=headers)
+    assert response.status_code == 200
+    assert get_task_link("123") is None
+
+
+@patch("app.validate_hmac", side_effect=mock_validate_hmac)
+@patch("app.requests.post")
+def test_item_completed_sends_beeminder(mock_post, mock_hmac, client):
+    """Completion of a linked task sends a Beeminder datapoint."""
+    setup_in_memory_db()
+    add_task_link("123", "salah")
+    os.environ["BEEMINDER_AUTH_TOKEN"] = "token"
+    mock_post.return_value.status_code = 200
+    payload = {
+        "event_name": "item:completed",
+        "event_id": "abc123",
+        "event_data": {"id": "123"},
+    }
+    headers = {"X-Todoist-Hmac-SHA256": "mock"}
+    response = client.post("/webhook", json=payload, headers=headers)
+    assert response.status_code == 200
+    assert mock_post.called
+    url = mock_post.call_args[0][0]
+    assert "salah" in url
+    assert mock_post.call_args[1]["data"]["requestid"] == "abc123"
 
 #
 # NEW TEST: Ensures that elapsed times above an hour are correctly merged.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,7 +12,6 @@ os.environ.setdefault("TODOIST_CLIENT_SECRET", "secret")
 fd, default_db_path = tempfile.mkstemp()
 os.close(fd)
 os.environ.setdefault("TASK_LINK_DB", default_db_path)
-
 from app import app, timers, init_db, get_task_link, add_task_link
 
 @pytest.fixture

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,6 +12,7 @@ os.environ.setdefault("TODOIST_CLIENT_SECRET", "secret")
 fd, default_db_path = tempfile.mkstemp()
 os.close(fd)
 os.environ.setdefault("TASK_LINK_DB", default_db_path)
+
 from app import app, timers, init_db, get_task_link, add_task_link
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- log successful Beeminder datapoint submissions for easier debugging
- use temporary DB path in tests and add persistence test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a23b9a26d8832cb133fc22272d6505